### PR TITLE
feat: add redirect_force_external label for forced external URL redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ WatchCow 监控 Docker 容器事件，自动将带有 `watchcow.enable=true` 标
 - **灵活配置** - 通过 Docker labels 自定义应用信息
 - **图标支持** - 支持 HTTP URL 或本地文件 (`file://...`) 作为图标，自动转换多种格式
 - **Dashboard** - 内置应用管理面板，可通过应用商店打开，查看和管理所有 WatchCow 应用
-- **URL 重定向** - 支持 `watchcow.redirect` 配置外部链接跳转
+- **URL 重定向** - 支持 `watchcow.redirect` 配置外部链接跳转，支持 `watchcow.redirect_force_external` 强制走外部地址
 
 ![Dashboard](README.assets/dashboard.png)
 
@@ -122,6 +122,7 @@ services:
 | `watchcow.protocol` | 否 | `http` | 协议 (`http`/`https`) |
 | `watchcow.path` | 否 | `/` | URL 路径 |
 | `watchcow.redirect` | 否 | - | 外部跳转 URL，设置后忽略 port/protocol/path，直接跳转到指定地址 |
+| `watchcow.redirect_force_external` | 否 | `false` | 设为 `true` 时跳过内网检测，始终跳转到外部地址（适用于 Vaultwarden 等必须通过域名 HTTPS 访问的应用） |
 | `watchcow.ui_type` | 否 | `url` | UI 类型 (`url` 新标签页 / `iframe` 桌面窗口) |
 | `watchcow.all_users` | 否 | `true` | 访问权限 (`true` 所有用户 / `false` 仅管理员) |
 | `watchcow.title` | 否 | `display_name` | 入口标题 |
@@ -142,6 +143,7 @@ WatchCow 支持为单个应用配置多个入口。使用 `watchcow.<entry>.<fie
 | `watchcow.<entry>.protocol` | 入口协议 |
 | `watchcow.<entry>.path` | 入口路径 |
 | `watchcow.<entry>.redirect` | 外部跳转 URL |
+| `watchcow.<entry>.redirect_force_external` | 设为 `true` 时跳过内网检测，始终跳转到外部地址 |
 | `watchcow.<entry>.ui_type` | 入口 UI 类型 |
 | `watchcow.<entry>.all_users` | 入口访问权限 |
 | `watchcow.<entry>.title` | 入口标题（默认：`display_name - entry`） |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -69,6 +69,7 @@ type Entry struct {
 	NoDisplay bool          // Hide from desktop (only show in right-click menu)
 	Control   *EntryControl // Permission control settings
 	Redirect  string        // External redirect host for CGI mode
+	ForceExternal bool      // Skip local network detection, always redirect to external URL
 }
 
 // GetRedirectConfig returns RedirectConfig if redirect is enabled, nil otherwise

--- a/internal/docker/monitor.go
+++ b/internal/docker/monitor.go
@@ -40,17 +40,18 @@ type StoredConfig struct {
 
 // StoredEntry represents a saved entry configuration.
 type StoredEntry struct {
-	Name       string
-	Title      string
-	Protocol   string
-	Port       string
-	Path       string
-	UIType     string
-	AllUsers   bool
-	FileTypes  []string
-	NoDisplay  bool
-	Redirect   string
-	IconBase64 string
+	Name          string
+	Title         string
+	Protocol      string
+	Port          string
+	Path          string
+	UIType        string
+	AllUsers      bool
+	FileTypes     []string
+	NoDisplay     bool
+	Redirect      string
+	ForceExternal bool
+	IconBase64    string
 }
 
 // AppOperation represents an operation to be processed serially
@@ -378,9 +379,10 @@ func (m *Monitor) generateFromStoredConfig(ctx context.Context, containerID stri
 			UIType:    e.UIType,
 			AllUsers:  e.AllUsers,
 			FileTypes: e.FileTypes,
-			NoDisplay: e.NoDisplay,
-			Redirect:  e.Redirect,
-			Icon:      storedCfg.IconBase64, // Base64 data from dashboard upload
+			NoDisplay:     e.NoDisplay,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
+			Icon:          storedCfg.IconBase64, // Base64 data from dashboard upload
 		}
 		config.Entries = append(config.Entries, entry)
 	}
@@ -421,16 +423,17 @@ func (m *Monitor) registerAppFromStoredConfig(storedCfg *StoredConfig, container
 
 	for _, e := range storedCfg.Entries {
 		entry := app.Entry{
-			Name:      e.Name,
-			Title:     e.Title,
-			Protocol:  e.Protocol,
-			Port:      e.Port,
-			Path:      e.Path,
-			UIType:    e.UIType,
-			AllUsers:  e.AllUsers,
-			FileTypes: e.FileTypes,
-			NoDisplay: e.NoDisplay,
-			Redirect:  e.Redirect,
+			Name:          e.Name,
+			Title:         e.Title,
+			Protocol:      e.Protocol,
+			Port:          e.Port,
+			Path:          e.Path,
+			UIType:        e.UIType,
+			AllUsers:      e.AllUsers,
+			FileTypes:     e.FileTypes,
+			NoDisplay:     e.NoDisplay,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
 		}
 		appInstance.Entries = append(appInstance.Entries, entry)
 	}
@@ -782,12 +785,13 @@ func (m *Monitor) registerAppFromConfig(config *fpkgen.AppConfig, containerID, c
 	// Convert entries
 	for _, e := range config.Entries {
 		entry := app.Entry{
-			Name:     e.Name,
-			Title:    e.Title,
-			Protocol: e.Protocol,
-			Port:     e.Port,
-			Path:     e.Path,
-			Redirect: e.Redirect,
+			Name:          e.Name,
+			Title:         e.Title,
+			Protocol:      e.Protocol,
+			Port:          e.Port,
+			Path:          e.Path,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
 		}
 		appInstance.Entries = append(appInstance.Entries, entry)
 	}
@@ -819,12 +823,13 @@ func (m *Monitor) registerAppFromLabels(appName, containerID, containerName stri
 	entries := fpkgen.ParseEntries(labels, appInstance.DisplayName, defaultIcon, defaultPort)
 	for _, e := range entries {
 		entry := app.Entry{
-			Name:     e.Name,
-			Title:    e.Title,
-			Protocol: e.Protocol,
-			Port:     e.Port,
-			Path:     e.Path,
-			Redirect: e.Redirect,
+			Name:          e.Name,
+			Title:         e.Title,
+			Protocol:      e.Protocol,
+			Port:          e.Port,
+			Path:          e.Path,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
 		}
 		appInstance.Entries = append(appInstance.Entries, entry)
 	}

--- a/internal/fpkgen/generator.go
+++ b/internal/fpkgen/generator.go
@@ -224,6 +224,7 @@ func (g *Generator) extractConfig(container *dockercontainer.InspectResponse) *A
 			NoDisplay: getLabel(labels, "watchcow.no_display", "false") == "true",
 			Control:   nil,
 			Redirect:  getLabel(labels, "watchcow.redirect", ""),
+			ForceExternal: getLabel(labels, "watchcow.redirect_force_external", "false") == "true",
 		}}
 	}
 
@@ -398,41 +399,43 @@ func prettifyName(name string) string {
 
 // entryFields defines which label suffixes are entry-specific configuration fields
 var entryFields = map[string]bool{
-	"service_port":        true,
-	"protocol":            true,
-	"path":                true,
-	"ui_type":             true,
-	"all_users":           true,
-	"icon":                true,
-	"title":               true,
-	"file_types":          true,
-	"no_display":          true,
-	"control.access_perm": true,
-	"control.port_perm":   true,
-	"control.path_perm":   true,
-	"redirect":            true,
+	"service_port":          true,
+	"protocol":              true,
+	"path":                  true,
+	"ui_type":               true,
+	"all_users":             true,
+	"icon":                  true,
+	"title":                 true,
+	"file_types":            true,
+	"no_display":            true,
+	"control.access_perm":   true,
+	"control.port_perm":     true,
+	"control.path_perm":     true,
+	"redirect":              true,
+	"redirect_force_external": true,
 }
 
 var reservedEntryNames = map[string]bool{
-	"enable":         true,
-	"install":        true,
-	"install_volume": true,
-	"appname":        true,
-	"display_name":   true,
-	"desc":           true,
-	"version":        true,
-	"maintainer":     true,
-	"service_port":   true,
-	"protocol":       true,
-	"path":           true,
-	"ui_type":        true,
-	"all_users":      true,
-	"icon":           true,
-	"title":          true,
-	"file_types":     true,
-	"no_display":     true,
-	"control":        true,
-	"redirect":       true,
+	"enable":                  true,
+	"install":                 true,
+	"install_volume":          true,
+	"appname":                 true,
+	"display_name":            true,
+	"desc":                    true,
+	"version":                 true,
+	"maintainer":              true,
+	"service_port":            true,
+	"protocol":                true,
+	"path":                    true,
+	"ui_type":                 true,
+	"all_users":               true,
+	"icon":                    true,
+	"title":                   true,
+	"file_types":              true,
+	"no_display":              true,
+	"control":                 true,
+	"redirect":                true,
+	"redirect_force_external": true,
 }
 
 // isEntryField checks if a field name is an entry configuration field
@@ -542,6 +545,7 @@ func parseEntry(labels map[string]string, name string, displayName string, defau
 		NoDisplay: getLabel(labels, prefix+"no_display", "false") == "true",
 		Control:   control,
 		Redirect:  getLabel(labels, prefix+"redirect", ""),
+		ForceExternal: getLabel(labels, prefix+"redirect_force_external", "false") == "true",
 	}
 }
 

--- a/internal/fpkgen/template.go
+++ b/internal/fpkgen/template.go
@@ -193,6 +193,7 @@ type EntryData struct {
 	NoDisplay bool              // Hide from desktop
 	Control   *EntryControlData // Permission control
 	Redirect  string            // External redirect host for CGI mode
+	ForceExternal bool          // Skip local network detection, always redirect to external URL
 }
 
 // TemplateData holds all data needed for template rendering
@@ -329,6 +330,7 @@ func NewTemplateData(config *AppConfig) *TemplateData {
 			NoDisplay: entry.NoDisplay,
 			Control:   controlData,
 			Redirect:  entry.Redirect,
+			ForceExternal: entry.ForceExternal,
 		})
 
 		// Track first displayable entry for default launch entry

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -533,17 +533,18 @@ func (h *DashboardHandler) convertToDockerConfig(config *StoredConfig) *docker.S
 
 	for _, e := range config.Entries {
 		result.Entries = append(result.Entries, docker.StoredEntry{
-			Name:       e.Name,
-			Title:      e.Title,
-			Protocol:   e.Protocol,
-			Port:       e.Port,
-			Path:       e.Path,
-			UIType:     e.UIType,
-			AllUsers:   e.AllUsers,
-			FileTypes:  e.FileTypes,
-			NoDisplay:  e.NoDisplay,
-			Redirect:   e.Redirect,
-			IconBase64: e.IconBase64,
+			Name:          e.Name,
+			Title:         e.Title,
+			Protocol:      e.Protocol,
+			Port:          e.Port,
+			Path:          e.Path,
+			UIType:        e.UIType,
+			AllUsers:      e.AllUsers,
+			FileTypes:     e.FileTypes,
+			NoDisplay:     e.NoDisplay,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
+			IconBase64:    e.IconBase64,
 		})
 	}
 

--- a/internal/server/redirect.go
+++ b/internal/server/redirect.go
@@ -84,6 +84,8 @@ type redirectTemplateData struct {
 	// Request components
 	Path        string // path from request
 	QueryString string // query string from request
+	// Behavior
+	ForceExternal bool // skip local network detection, always redirect to external URL
 	// Assets
 	BulmaCSS template.CSS // Bulma CSS content
 }
@@ -134,7 +136,7 @@ func (h *RedirectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.outputHTML(w, entry.Redirect, entry.Port, path, sanitizeQueryString(r.URL.RawQuery))
+	h.outputHTML(w, entry.Redirect, entry.Port, path, sanitizeQueryString(r.URL.RawQuery), entry.ForceExternal)
 }
 
 // outputError outputs an error page
@@ -145,7 +147,7 @@ func (h *RedirectHandler) outputError(w http.ResponseWriter, status int, msg str
 }
 
 // outputHTML outputs the redirect HTML page with JavaScript
-func (h *RedirectHandler) outputHTML(w http.ResponseWriter, redirectHost, containerPort, path, queryString string) {
+func (h *RedirectHandler) outputHTML(w http.ResponseWriter, redirectHost, containerPort, path, queryString string, forceExternal bool) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 
@@ -183,6 +185,7 @@ func (h *RedirectHandler) outputHTML(w http.ResponseWriter, redirectHost, contai
 		ContainerPort: containerPort,
 		Path:          path,
 		QueryString:   queryString,
+		ForceExternal: forceExternal,
 		BulmaCSS:      template.CSS(cssBytes),
 	}
 

--- a/internal/server/storage.go
+++ b/internal/server/storage.go
@@ -182,17 +182,18 @@ func (s *DashboardStorage) GetByKey(key string) *docker.StoredConfig {
 
 	for _, e := range cfg.Entries {
 		result.Entries = append(result.Entries, docker.StoredEntry{
-			Name:       e.Name,
-			Title:      e.Title,
-			Protocol:   e.Protocol,
-			Port:       e.Port,
-			Path:       e.Path,
-			UIType:     e.UIType,
-			AllUsers:   e.AllUsers,
-			FileTypes:  e.FileTypes,
-			NoDisplay:  e.NoDisplay,
-			Redirect:   e.Redirect,
-			IconBase64: e.IconBase64,
+			Name:          e.Name,
+			Title:         e.Title,
+			Protocol:      e.Protocol,
+			Port:          e.Port,
+			Path:          e.Path,
+			UIType:        e.UIType,
+			AllUsers:      e.AllUsers,
+			FileTypes:     e.FileTypes,
+			NoDisplay:     e.NoDisplay,
+			Redirect:      e.Redirect,
+			ForceExternal: e.ForceExternal,
+			IconBase64:    e.IconBase64,
 		})
 	}
 

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -46,17 +46,18 @@ func (k ContainerKey) Image() string {
 
 // StoredEntry represents a saved entry configuration.
 type StoredEntry struct {
-	Name       string   // Entry identifier (empty for default entry)
-	Title      string   // Display title
-	Protocol   string   // http or https
-	Port       string   // Service port
-	Path       string   // URL path
-	UIType     string   // "url" (new tab) or "iframe" (desktop window)
-	AllUsers   bool     // Access permission (true = all users)
-	FileTypes  []string // Supported file types for right-click menu
-	NoDisplay  bool     // Hide from desktop
-	Redirect   string   // External redirect host
-	IconBase64 string   // Base64-encoded PNG icon for this entry
+	Name          string   // Entry identifier (empty for default entry)
+	Title         string   // Display title
+	Protocol      string   // http or https
+	Port          string   // Service port
+	Path          string   // URL path
+	UIType        string   // "url" (new tab) or "iframe" (desktop window)
+	AllUsers      bool     // Access permission (true = all users)
+	FileTypes     []string // Supported file types for right-click menu
+	NoDisplay     bool     // Hide from desktop
+	Redirect      string   // External redirect host
+	ForceExternal bool     // Skip local network detection, always redirect to external URL
+	IconBase64    string   // Base64-encoded PNG icon for this entry
 }
 
 // StoredConfig represents a saved container configuration.

--- a/watchcow-labels-skill/SKILL.md
+++ b/watchcow-labels-skill/SKILL.md
@@ -54,6 +54,7 @@ These control how the app appears and opens in fnOS:
 | `watchcow.protocol` | `http` | `http` or `https` |
 | `watchcow.path` | `/` | URL path |
 | `watchcow.redirect` | — | External URL; when set, port/protocol/path are ignored and the app opens this URL directly |
+| `watchcow.redirect_force_external` | `false` | `"true"` skips local network detection and always redirects to the external URL (useful for apps like Vaultwarden that require HTTPS via domain) |
 | `watchcow.ui_type` | `url` | `url` (new browser tab) or `iframe` (desktop window) |
 | `watchcow.all_users` | `true` | `"true"` = all users, `"false"` = admin only |
 | `watchcow.title` | same as `display_name` | Entry title |
@@ -79,6 +80,7 @@ watchcow.<entry>.service_port
 watchcow.<entry>.protocol
 watchcow.<entry>.path
 watchcow.<entry>.redirect
+watchcow.<entry>.redirect_force_external
 watchcow.<entry>.ui_type
 watchcow.<entry>.all_users
 watchcow.<entry>.title          # defaults to "<display_name> - <entry>"

--- a/web/templates/redirect.tmpl
+++ b/web/templates/redirect.tmpl
@@ -191,7 +191,7 @@
         async function main() {
             // If force external is enabled, skip local network detection entirely
             if (FORCE_EXTERNAL) {
-                setStatus('External network detected');
+                setStatus('Force external detected, skipping local network detection...');
                 redirectTo(buildExternalURL());
                 return;
             }

--- a/web/templates/redirect.tmpl
+++ b/web/templates/redirect.tmpl
@@ -43,6 +43,8 @@
         // Request components
         const PATH = '{{.Path | js}}';                    // e.g., "/path2" (sanitized)
         const QUERY_STRING = '{{.QueryString | js}}';     // e.g., "y=2" (sanitized)
+        // Behavior
+        const FORCE_EXTERNAL = {{.ForceExternal}};        // skip local network detection
 
         const statusEl = document.getElementById('status');
         const errorEl = document.getElementById('error');
@@ -187,6 +189,13 @@
 
         // Main logic
         async function main() {
+            // If force external is enabled, skip local network detection entirely
+            if (FORCE_EXTERNAL) {
+                setStatus('External network detected');
+                redirectTo(buildExternalURL());
+                return;
+            }
+
             // First, quick check based on hostname
             if (isLocalHostname()) {
                 setStatus('Local network detected, verifying access...');


### PR DESCRIPTION
## Summary

Adds `watchcow.redirect_force_external` label to optionally skip local network detection and always redirect to the external URL. Useful for apps like Vaultwarden that must be accessed via domain name + HTTPS.

## Changes

- **New label**: `watchcow.<entry>.redirect_force_external` (`true`/`false`, default `false`)
  - When `true`, the redirect handler skips local IP/DNS resolution and immediately redirects to the configured external URL
  - Works for both default entry and named entries (e.g., `watchcow.main.redirect_force_external`)
- **Bug fix**: `ForceExternal` field was not being copied through all entry conversion paths (`generateFromStoredConfig` → `Entry` struct), causing the label to silently default to `false` when the config flowed through the Dashboard stored config path